### PR TITLE
Add compatibility notice for 6.2.60 release.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@
 
 [Full Changelog](https://github.com/sympa-community/sympa/compare/6.2.59b.1...6.2.60)
 
+**Compatibility notice**
+
+The behaviour of the personalization / merge feature has been changed and may
+affect the processing of your emails. We strongly recommend to read the
+[Upgrading notes](https://sympa-community.github.io/manual/upgrade/notes.html#from-version-prior-to-6260)
+if you have this feature enabled globally or for some lists.
+
 **Changes (since 6.2.58)**:**
 
 - This release includes a security fix for \[CVE-2020-29668\] (Unauthorised full access via SOAP API due to illegal cookie).  If you are running SOAP/HTTP interface (`sympa_soap_sever.fcgi`), upgrading is strongly recommended. See also [Security Advisory](https://sympa-community.github.io/security/2020-003.html) for details.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # Change Log
 
+## [6.2.60](https://github.com/sympa-community/sympa/tree/6.2.60) (2020-12-XX)
+
+[Full Changelog](https://github.com/sympa-community/sympa/compare/6.2.59b.1...6.2.60)
+
+**Changes (since 6.2.58)**:**
+
+- This release includes a security fix for \[CVE-2020-29668\] (Unauthorised full access via SOAP API due to illegal cookie).  If you are running SOAP/HTTP interface (`sympa_soap_sever.fcgi`), upgrading is strongly recommended. See also [Security Advisory](https://sympa-community.github.io/security/2020-003.html) for details.
+- Personalization (also known as “merge feature”) is restricted by default, and the restrictions can be configured.  See [Upgrading notes](https://sympa-community.github.io/manual/upgrade/notes.html#from-version-prior-to-6260) for details.
+- Several options at installation and run time to get rid of setuid wrappers were introduced.  See [Upgrading notes](https://sympa-community.github.io/manual/upgrade/notes.html#from-version-prior-to-6260) for details.
+
+**Implemented enhancements:**
+
+**Fixed bugs:**
+
+- Missing language on edit subscriber view [\#1048](https://github.com/sympa-community/sympa/issues/1048)
+- \[CVE-2020-29668\] Unauthorised full access via SOAP API due to illegal cookie [\#1041](https://github.com/sympa-community/sympa/issues/1041)
+- Personalization \(merge\_feature\) should be limited [\#1037](https://github.com/sympa-community/sympa/issues/1037)
+- ldap ssl connexion no error message [\#596](https://github.com/sympa-community/sympa/issues/596)
+- Add proper exit code on errors to SOAP client script. [\#1043](https://github.com/sympa-community/sympa/pull/1043) ([racke](https://github.com/racke))
+- DKIM signing not working if `dkim_feature` in domain context was not enabled [\#1036](https://github.com/sympa-community/sympa/issues/1036)
+
 ## [6.2.59b.2](https://github.com/sympa-community/sympa/tree/6.2.59b.2) (2020-12-07)
 
 [Full Changelog](https://github.com/sympa-community/sympa/compare/6.2.59b.1...6.2.59b.2)

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 AC_PREREQ(2.60)
-AC_INIT(sympa, 6.2.59b.2, sympa-developpers@listes.renater.fr)
+AC_INIT(sympa, 6.2.60, sympa-developpers@listes.renater.fr)
 AM_INIT_AUTOMAKE([foreign -Wall -Werror 1.9 tar-pax])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_PO_SUBDIRS


### PR DESCRIPTION
The idea is to highlight changes that affect an existing installation in an unexpected way and may require listmasters to adjust their configuration.